### PR TITLE
Various fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ else
 endif
 
 # Build tools
-VASM_HOME = /opt/vasm
+VASM_HOME ?= /opt/vasm
 VASM = $(VASM_HOME)/bin/vasmm68k_mot
 EXPECTED_VASM_VERSION = 2.0e
 

--- a/src/fat95.s
+++ b/src/fat95.s
@@ -4711,8 +4711,11 @@ _r_error:
 	bsr	DoRequest
 	add.w	#12,sp
 	tst.w	d0
-	bne.w	_r_group		;"repeat"
-
+	beq.s	_r_giveup
+	tst.w	DiskChanged(a4)		;media swapped during the requester?
+	bne.s	_r_giveup		;abort: layout we cached is stale
+	bra.w	_r_group		;"repeat"
+_r_giveup:
 	move.w	#225,ErrorNum(a4)
 	bra.s	_r_end
 
@@ -4805,8 +4808,11 @@ _w_error:
 	bsr	DoRequest
 	add.w	#12,sp
 	tst.w	d0
-	bne.w	_w_group		;"repeat"
-
+	beq.s	_w_giveup
+	tst.w	DiskChanged(a4)		;media swapped during the requester?
+	bne.s	_w_giveup		;abort: layout we cached is stale
+	bra.w	_w_group		;"repeat"
+_w_giveup:
 	move.w	#225,ErrorNum(a4)
 	bra.s	_w_end
 

--- a/src/fat95.s
+++ b/src/fat95.s
@@ -9598,7 +9598,7 @@ pfe_end:
 ; d0 -> ULONG new Cluster # or -1;
 
 ExtendChain:
-	movem.l	d2-d4,-(sp)
+	movem.l	d2-d5,-(sp)
 	move.l	d0,d2
 	beq.s	xch_add			;start new chain
 xch_search:
@@ -9615,12 +9615,21 @@ xch_add:
 
 	move.l	LastCluster(a4),d3
 	addq.l	#1,d3
+;	Watchdog: at most (LastCluster - 1) data clusters exist, so the
+;	wrap-around scan visits each one at most once.  If FreeClusters
+;	is stale (e.g. FAT read errors filled the buffer with the "end
+;	of chain" placeholder) we'd otherwise spin forever -- catch it
+;	here and report disk full instead.
+	move.l	d3,d5
+	subq.l	#2,d5
 	move.l	d2,d4			;# predictor
 	bgt.s	xch_loop
 
 	move.l	NextFreeCluster(a4),d2
 	subq.l	#1,d2
 xch_loop:
+	subq.l	#1,d5
+	bmi.s	xch_error
 	addq.l	#1,d2			;scan pred+1 ~ n-1..
 	cmp.l	d3,d2
 	bcs.s	xch_2
@@ -9644,7 +9653,7 @@ xch_2:
 	bsr	PutFATEntry		;..append there
 xch_end:
 	move.l	d2,d0
-	movem.l	(sp)+,d2-d4
+	movem.l	(sp)+,d2-d5
 	rts
 
 xch_error:

--- a/src/fat95.s
+++ b/src/fat95.s
@@ -9007,6 +9007,29 @@ rf_scan:
 	move.l	LastCluster(a4),d2
 	moveq.l	#0,d3
 	moveq.l	#0,d4
+	tst.w	FATType(a4)
+	beq.s	rf_count		;FAT12: keep the GetFATEntry-based scan
+
+;	FAT16 fast path -- the on-disk entry is a little-endian word; 0
+;	means free regardless of byte order, so we can skip the per-cluster
+;	GetFATEntry call (saves a bsr + ReverseW + cmp for every cluster).
+	move.l	FATBuffer(a4),a0
+	move.l	d2,d0
+	add.l	d0,d0
+	add.l	d0,a0			;a0 -> entry for LastCluster
+rf_c16:
+	tst.w	(a0)
+	bne.s	rf_c16next
+	addq.l	#1,d3
+	move.l	d2,d4
+rf_c16next:
+	subq.l	#2,a0
+	subq.l	#1,d2
+	moveq.l	#2,d0
+	cmp.l	d0,d2
+	bcc.s	rf_c16
+	bra.s	rf_cdone
+
 rf_count:
 	move.l	d2,d0
 	bsr	GetFATEntry		;scan FAT..
@@ -9020,7 +9043,7 @@ rf_cnext:
 	moveq.l	#2,d0
 	cmp.l	d0,d2
 	bcc.s	rf_count
-
+rf_cdone:
 	move.l	d3,FreeClusters(a4)
 	move.l	d4,NextFreeCluster(a4)
 	bra.w	rf_end

--- a/src/fat95.s
+++ b/src/fat95.s
@@ -10470,11 +10470,37 @@ wtf_ready:				;all done!!!
 	move.l	XL_Parent(a0),a1
 	or.w	#$8000,XL_Flags(a1)
 wtf_r1:
-	tst.l	d4			;on success..
-	bne.s	wtf_r2
-
-	move.l	d1,XFH_CurrentPos(a2)	;..set new Position
+	move.l	d1,XFH_CurrentPos(a2)	;always advance position by bytes written
+	tst.l	d4
+	bne.s	wtf_rwalk		;partial write: recompute current cluster
 	move.l	WTF_CLUSTER(a5),XFH_Cluster(a2)
+	bra.s	wtf_r2
+
+;	on a short write WTF_CLUSTER may be the "next swath" pointer or even
+;	-1 (disk full), so it can't be used as the current-position cluster.
+;	Walk the FAT from MSDE_1L to find the cluster that holds WTF_POS.
+wtf_rwalk:
+	moveq.l	#0,d0
+	tst.w	FATType(a4)
+	bpl.s	wtf_rw_lo
+	move.w	XL_MSDE+MSDE_1H(a0),d0
+	swap	d0
+wtf_rw_lo:
+	move.w	XL_MSDE+MSDE_1L(a0),d0
+	move.w	BlockShift(a4),d3
+	add.w	ClusterShift(a4),d3
+	lsr.l	d3,d1			;d1 = cluster index of WTF_POS
+	bra.s	wtf_rw_test
+wtf_rw_walk:
+	tst.l	d0
+	ble.s	wtf_rw_done		;chain exhausted; leave sentinel in d0
+	bsr	NextCluster
+	subq.l	#1,d1
+wtf_rw_test:
+	tst.l	d1
+	bgt.s	wtf_rw_walk
+wtf_rw_done:
+	move.l	d0,XFH_Cluster(a2)
 wtf_r2:
 	move.l	d7,d0
 	move.l	a2,a0

--- a/src/fat95.s
+++ b/src/fat95.s
@@ -4674,6 +4674,13 @@ _r_1:
 	bsr	SafeDoIO
 	bra.s	_r_check
 _r_scsi:
+	cmp.l	#$ffff,d3		;READ10 takes a 16-bit block count
+	bls.s	_r_scsi_go
+	move.l	#$ffff,d3
+	move.w	BlockShift(a4),d1
+	move.l	d3,d6
+	lsl.l	d1,d6
+_r_scsi_go:
 	moveq.l	#READ10,d0
 	moveq.l	#SCSIF_READ,d1
 	bsr	Do10byteScsi
@@ -4761,6 +4768,13 @@ _w_1:
 	bsr	SafeDoIO
 	bra.s	_w_check
 _w_scsi:
+	cmp.l	#$ffff,d3		;WRITE10 takes a 16-bit block count
+	bls.s	_w_scsi_go
+	move.l	#$ffff,d3
+	move.w	BlockShift(a4),d1
+	move.l	d3,d6
+	lsl.l	d1,d6
+_w_scsi_go:
 	moveq.l	#WRITE10,d0
 	moveq.l	#SCSIF_WRITE,d1
 	bsr	Do10byteScsi

--- a/src/fat95.s
+++ b/src/fat95.s
@@ -8114,9 +8114,20 @@ xtd_i1:
 
 	move.l	d0,a0			;of &XLock of parent dir..
 xtd_i2:
+	move.l	a0,d0			;remember parent XLock; MakeIntRef clobbers a0
 	lea	MSDE_Sizeof(a2),a1
 	bsr	MakeIntRef		;..copy dir descriptor..
 	move.w	#"..",MSDE_Sizeof(a2)	;..as parent link
+	move.l	d0,a0
+	tst.l	XL_Parent(a0)
+	bne.s	xtd_idone
+;	Microsoft FAT spec: when the parent is the root, ".." must hold
+;	cluster 0, not the actual root cluster.  Linux and Windows
+;	tolerate either form, but fsck.vfat flags the non-zero variant
+;	on FAT32 volumes.
+	clr.w	MSDE_Sizeof+MSDE_1L(a2)
+	clr.w	MSDE_Sizeof+MSDE_1H(a2)
+xtd_idone:
 	moveq.l	#-1,d0
 	move.l	d0,EXD_CLUSTER(a5)	;"initialized"
 	bra.s	xtd_write


### PR DESCRIPTION
- **build: let env override VASM_HOME**
- **fat95: advance file position on short writes**
- **fat95: clamp SCSI READ10/WRITE10 block count to 16 bits**
- **fat95: bail out of I/O retry if disk was swapped**
- **fat95: zero the ".." cluster for subdirs of FAT32 root**
- **fat95: bound the free-cluster scan in ExtendChain**
- **fat95: inline FAT16 free-cluster scan on mount**
